### PR TITLE
Fix: Address CSS loading, Supabase init, and webhint warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-        // Garantir que o objeto supabase está disponível globalmente
-        window.supabase = window.supabaseJs || window.supabase;
-    </script>
     <script src="js/supabase.js"></script>
     <script src="js/auth.js"></script>
     <script src="js/app.js"></script>
@@ -54,7 +50,7 @@
                     <div class="file-upload" id="odoo-upload">
                         <i class="fas fa-file-excel file-upload-icon"></i>
                         <p class="file-upload-text">Arraste e solte o arquivo Odoo aqui ou clique para selecionar</p>
-                        <input type="file" id="odoo-file" class="hidden" accept=".xlsx, .xls">
+                        <input type="file" id="odoo-file" class="hidden" accept=".xlsx, .xls" title="Input do arquivo Odoo">
                         <button class="btn btn-primary">Selecionar Arquivo</button>
                     </div>
                     <div id="odoo-file-info" class="hidden">
@@ -69,7 +65,7 @@
                     <div class="file-upload" id="backoffice-upload">
                         <i class="fas fa-file-excel file-upload-icon"></i>
                         <p class="file-upload-text">Arraste e solte o arquivo Back Office aqui ou clique para selecionar</p>
-                        <input type="file" id="backoffice-file" class="hidden" accept=".xlsx, .xls">
+                        <input type="file" id="backoffice-file" class="hidden" accept=".xlsx, .xls" title="Input do arquivo Back Office">
                         <button class="btn btn-primary">Selecionar Arquivo</button>
                     </div>
                     <div id="backoffice-file-info" class="hidden">
@@ -152,7 +148,7 @@
                     <div class="file-upload" id="caixa-upload">
                         <i class="fas fa-file-excel file-upload-icon"></i>
                         <p class="file-upload-text">Arraste e solte o arquivo de Caixa aqui ou clique para selecionar</p>
-                        <input type="file" id="caixa-file" class="hidden" accept=".xlsx, .xls">
+                        <input type="file" id="caixa-file" class="hidden" accept=".xlsx, .xls" title="Input do arquivo de Caixa">
                         <button class="btn btn-primary">Selecionar Arquivo</button>
                     </div>
                     <div id="caixa-file-info" class="hidden">

--- a/js/supabase.js
+++ b/js/supabase.js
@@ -10,20 +10,17 @@ let supabase;
 
 // Função para inicializar o cliente Supabase
 function initSupabase() {
-    if (typeof window.supabase !== 'undefined') {
-        // Usar o objeto global supabase diretamente
-        supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-        console.log('Cliente Supabase inicializado com sucesso (método global)');
-    } else if (typeof supabaseClient !== 'undefined') {
-        // Fallback para supabaseClient se disponível
-        supabase = supabaseClient.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-        console.log('Cliente Supabase inicializado com sucesso (método cliente)');
-    } else if (typeof window.supabaseJs !== 'undefined') {
-        // Fallback para supabaseJs se disponível
+    if (typeof window.supabaseJs !== 'undefined' && typeof window.supabaseJs.createClient === 'function') {
         supabase = window.supabaseJs.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-        console.log('Cliente Supabase inicializado com sucesso (método JS)');
+        console.log('Supabase client initialized using window.supabaseJs.createClient');
+    } else if (typeof window.supabase !== 'undefined' && typeof window.supabase.createClient === 'function') { 
+        // Fallback for any existing global supabase object that might have been set up by other means,
+        // though the primary method (supabaseJs) is preferred.
+        supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+        console.warn('Supabase client initialized using a global window.supabase. Consider standardizing to supabaseJs.');
     } else {
-        console.error('Biblioteca Supabase não carregada. Verifique se o script do CDN está incluído.');
+        console.error('Supabase library (supabaseJs) not loaded or createClient function not found. Ensure Supabase CDN script is included and loaded correctly before this script.');
+        // Optionally, throw an error or handle this case more gracefully depending on application requirements.
     }
 }
 

--- a/login.html
+++ b/login.html
@@ -8,10 +8,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    <script>
-        // Garantir que o objeto supabase está disponível globalmente
-        window.supabase = window.supabaseJs || window.supabase;
-    </script>
     <script src="js/supabase.js"></script>
     <script src="js/auth.js"></script>
 </head>
@@ -26,12 +22,12 @@
             <form id="login-form" class="login-form">
                 <div class="form-group">
                     <label for="email" class="form-label">Email</label>
-                    <input type="email" id="email" class="form-control" placeholder="Seu email" required>
+                    <input type="email" id="email" class="form-control" placeholder="Seu email" required title="Endereço de email">
                 </div>
                 
                 <div class="form-group">
                     <label for="password" class="form-label">Password</label>
-                    <input type="password" id="password" class="form-control" placeholder="Sua password" required>
+                    <input type="password" id="password" class="form-control" placeholder="Sua password" required title="Senha">
                 </div>
                 
                 <div id="login-error" class="status-error mb-10" style="display: none;"></div>

--- a/vercel.json
+++ b/vercel.json
@@ -4,12 +4,42 @@
     {
       "src": "*.html",
       "use": "@vercel/static"
+    },
+    {
+      "src": "css/**/*",
+      "use": "@vercel/static"
+    },
+    {
+      "src": "js/**/*",
+      "use": "@vercel/static"
     }
   ],
   "routes": [
     {
       "src": "/(.*)",
       "dest": "/$1"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-XSS-Protection", "value": "0" }
+      ]
+    },
+    {
+      "source": "/(css|js)/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.woff2",
+      "headers": [
+        { "key": "Content-Type", "value": "font/woff2" },
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
     }
   ],
   "github": {


### PR DESCRIPTION
This commit resolves several issues identified in the Caixa Multipark project:

1.  **Supabase Initialization:**
    *   I standardized Supabase client initialization in `js/supabase.js` to use `window.supabaseJs.createClient` as per Supabase v2 documentation.
    *   I removed redundant/conflicting Supabase initialization script blocks from `index.html` and `login.html`.
    This should improve the reliability of the connection to Supabase.

2.  **CSS and Static Asset Serving:**
    *   I verified that `css/styles.css` is syntactically correct.
    *   I updated `vercel.json` to set appropriate HTTP headers:
        *   `X-Content-Type-Options: nosniff` for all responses.
        *   `X-XSS-Protection: 0` (disabled deprecated XSS auditor).
        *   Long-lived `Cache-Control` headers (`public, max-age=31536000, immutable`) for assets in `/css/` and `/js/` directories.
        *   I ensured `.woff2` files are served with `Content-Type: font/woff2` and long-lived cache headers.
    These changes address various webhint warnings related to security and performance and ensure CSS/JS assets are cached effectively.

3.  **Accessibility:**
    *   I added `title` attributes to form input elements in `login.html` (email, password) and `index.html` (file inputs) to improve accessibility and resolve webhint warnings about missing form labels/attributes.

4.  **Webhint Warnings Review:**
    *   Other webhint warnings related to external resources (CDNs for fonts, libraries, browser extensions) were reviewed and confirmed as not actionable within this project's codebase.

These changes aim to fix the reported problems of CSS not being applied correctly (by ensuring proper serving and headers) and issues with Supabase connectivity, as well as improving overall code quality and security based on webhint recommendations.